### PR TITLE
Handle different return types for selector.

### DIFF
--- a/Code/Functions/MBMLFunction.m
+++ b/Code/Functions/MBMLFunction.m
@@ -852,7 +852,21 @@ NSString* const kMBMLFunctionInputParameterName         = @"input parameter";
         
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-        id output = [_functionClass performSelector:_functionSelector withObject:input];
+        id output = nil;
+        
+        NSMethodSignature* methodSig = [_functionClass methodSignatureForSelector:_functionSelector];
+        if(methodSig == nil)
+            return nil;
+        
+        const char* retType = [methodSig methodReturnType];
+        if(strcmp(retType, @encode(id)) == 0) {
+            output = [_functionClass performSelector:_functionSelector withObject:input];
+        } else if(strcmp(retType, @encode(void)) == 0) {
+            [_functionClass performSelector:_functionSelector withObject:input];
+        } else {
+            MBLogError(@"Expected id return type for %@ called with input %@ but got %s instead", self, input, retType);
+            return nil;
+        }
 #pragma clang diagnostic pop
 
 


### PR DESCRIPTION
For 'void' we should omit return value due to EXC_BAD_ACCESS crashes, for any other type than void or id (nonobject like C struct etc) we can't use perform selector, we need to use NSInvocation instead.

Error example for CGRect type (used just for test purposes)

```
ERROR | MBMLFunction.m:867 — Expected id return type for <MBMLFunction: 0x7fc05bdbcdc0; ^setCurrentProductInventoryStatus() implemented by +[ProductDetailController setCurrentProductInventoryStatus]> called with input (null) but got {CGRect={CGPoint=dd}{CGSize=dd}} instead
```
